### PR TITLE
Add suspend card/note dropdown

### DIFF
--- a/src/einki/_anki_client.py
+++ b/src/einki/_anki_client.py
@@ -215,6 +215,22 @@ class AnkiClient:
         LOG.info("Undo: %s", result)
         return result
 
+    def suspend_card(self, card_id: int) -> bool:
+        """Suspend a single card until the user manually unsuspends it."""
+        result: bool = self._invoke("suspend", cards=[card_id])
+        LOG.info("Suspended card %d: %s", card_id, result)
+        return result
+
+    def suspend_note(self, note_id: int) -> bool:
+        """Suspend every card belonging to a note."""
+        card_ids: list[int] = self._invoke("findCards", query=f"nid:{note_id}")
+        if not card_ids:
+            LOG.info("Suspend note %d: no cards found", note_id)
+            return False
+        result: bool = self._invoke("suspend", cards=card_ids)
+        LOG.info("Suspended note %d (%d cards): %s", note_id, len(card_ids), result)
+        return result
+
     def sync(self) -> None:
         """Sync the Anki collection with AnkiWeb."""
         self._invoke("sync")

--- a/src/einki/_app.py
+++ b/src/einki/_app.py
@@ -138,6 +138,12 @@ def _register_anki_routes(  # noqa: C901
         """Toggle the 'marked' tag on the current card's note."""
         return _handle_mark(anki_client)
 
+    @app.route("/suspend", methods=["POST"])
+    @flask_login.login_required  # type: ignore[untyped-decorator]
+    def suspend() -> werkzeug.Response:
+        """Suspend the current card or note, then advance to the next card."""
+        return _handle_suspend(anki_client)
+
 
 def _handle_mark(anki_client: AnkiClient | None) -> werkzeug.Response:
     """Toggle the 'marked' tag on the current card's note."""
@@ -149,6 +155,18 @@ def _handle_mark(anki_client: AnkiClient | None) -> werkzeug.Response:
     return flask.redirect(
         flask.url_for("study", deck=deck, answer_shown="1" if answer_shown else None),
     )
+
+
+def _handle_suspend(anki_client: AnkiClient | None) -> werkzeug.Response:
+    """Suspend the current card or note, then redirect to the next card."""
+    deck = flask.request.form["deck"]
+    scope = flask.request.form.get("scope")
+    if anki_client is not None and scope in ("card", "note"):
+        if scope == "card":
+            anki_client.suspend_card(int(flask.request.form["card_id"]))
+        else:
+            anki_client.suspend_note(int(flask.request.form["note_id"]))
+    return flask.redirect(flask.url_for("study", deck=deck))
 
 
 def _handle_undo(anki_client: AnkiClient | None) -> str | werkzeug.Response:

--- a/src/einki/templates/study.html
+++ b/src/einki/templates/study.html
@@ -89,6 +89,7 @@
             cursor: pointer;
             display: inline-block;
             line-height: 1.2;
+            white-space: nowrap;
         }
         .edit-menu > summary::-webkit-details-marker { display: none; }
         .edit-menu[open] > summary {

--- a/src/einki/templates/study.html
+++ b/src/einki/templates/study.html
@@ -80,36 +80,21 @@
             cursor: pointer;
         }
         .undo-btn:hover { background: #e9ecef; }
-        .mark-btn {
-            background: none;
-            border: 1px solid #dee2e6;
-            border-radius: 6px;
-            padding: 4px 12px;
-            font-size: 0.85rem;
-            color: #6c757d;
-            cursor: pointer;
-            white-space: nowrap;
-        }
-        .mark-btn:hover { background: #e9ecef; }
-        .mark-btn.marked {
-            background: #fff3cd;
-            border-color: #ffecb5;
-            color: #664d03;
-        }
-        .mark-btn.marked:hover { background: #ffe69c; }
-        .suspend-menu {
+        .edit-menu {
             position: relative;
             display: inline-block;
         }
-        .suspend-menu > summary {
+        .edit-menu > summary {
             list-style: none;
             cursor: pointer;
+            display: inline-block;
+            line-height: 1.2;
         }
-        .suspend-menu > summary::-webkit-details-marker { display: none; }
-        .suspend-menu[open] > summary {
+        .edit-menu > summary::-webkit-details-marker { display: none; }
+        .edit-menu[open] > summary {
             background: #e9ecef;
         }
-        .suspend-options {
+        .edit-panel {
             position: absolute;
             top: 100%;
             left: 0;
@@ -122,11 +107,25 @@
             border: 1px solid #dee2e6;
             border-radius: 6px;
             padding: 6px;
-            min-width: 80px;
+            min-width: 120px;
         }
-        .suspend-options .undo-btn { width: 100%; text-align: left; }
-        @media (max-width: 480px) {
-            .mark-label { display: none; }
+        .edit-panel .undo-btn,
+        .edit-panel > details > summary { width: 100%; text-align: left; box-sizing: border-box; }
+        .suspend-sub > summary {
+            list-style: none;
+            cursor: pointer;
+        }
+        .suspend-sub > summary::-webkit-details-marker { display: none; }
+        .suspend-sub[open] > summary {
+            background: #e9ecef;
+        }
+        .suspend-sub-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            margin-top: 4px;
+            padding-left: 12px;
+            border-left: 2px solid #dee2e6;
         }
         .stats {
             display: flex;
@@ -155,31 +154,36 @@
         <p class="header" style="margin:0;"><a href="/decks">← Decks</a> / {{ deck }}</p>
         <div style="display:flex;gap:8px;">
             {% if card %}
-            <details class="suspend-menu">
-                <summary class="undo-btn" title="Suspend">Suspend</summary>
-                <div class="suspend-options">
-                    <form method="post" action="/suspend" class="undo-form">
-                        <input type="hidden" name="deck" value="{{ deck }}">
-                        <input type="hidden" name="card_id" value="{{ card.card_id }}">
-                        <input type="hidden" name="scope" value="card">
-                        <button type="submit" class="undo-btn">Card</button>
-                    </form>
-                    <form method="post" action="/suspend" class="undo-form">
+            <details class="edit-menu">
+                <summary class="undo-btn" title="Edit">Edit ▾</summary>
+                <div class="edit-panel">
+                    <form method="post" action="/mark_card" class="undo-form">
                         <input type="hidden" name="deck" value="{{ deck }}">
                         <input type="hidden" name="note_id" value="{{ card.note_id }}">
-                        <input type="hidden" name="scope" value="note">
-                        <button type="submit" class="undo-btn">Note</button>
+                        <input type="hidden" name="answer_shown" value="{{ '1' if answer_shown else '0' }}" class="answer-shown-flag">
+                        <button type="submit" class="undo-btn" title="{{ 'Unmark' if card.is_marked else 'Mark' }}">
+                            {{ "Unmark" if card.is_marked else "Mark" }}
+                        </button>
                     </form>
+                    <details class="suspend-sub">
+                        <summary class="undo-btn" title="Suspend">Suspend ▸</summary>
+                        <div class="suspend-sub-panel">
+                            <form method="post" action="/suspend" class="undo-form">
+                                <input type="hidden" name="deck" value="{{ deck }}">
+                                <input type="hidden" name="card_id" value="{{ card.card_id }}">
+                                <input type="hidden" name="scope" value="card">
+                                <button type="submit" class="undo-btn">Card</button>
+                            </form>
+                            <form method="post" action="/suspend" class="undo-form">
+                                <input type="hidden" name="deck" value="{{ deck }}">
+                                <input type="hidden" name="note_id" value="{{ card.note_id }}">
+                                <input type="hidden" name="scope" value="note">
+                                <button type="submit" class="undo-btn">Note</button>
+                            </form>
+                        </div>
+                    </details>
                 </div>
             </details>
-            <form method="post" action="/mark_card" class="undo-form">
-                <input type="hidden" name="deck" value="{{ deck }}">
-                <input type="hidden" name="note_id" value="{{ card.note_id }}">
-                <input type="hidden" name="answer_shown" value="{{ '1' if answer_shown else '0' }}" class="answer-shown-flag">
-                <button type="submit" class="mark-btn {{ 'marked' if card.is_marked }}" title="{{ 'Unmark' if card.is_marked else 'Mark' }}">
-                    <span class="mark-star">{{ "★" if card.is_marked else "☆" }}</span><span class="mark-label"> {{ "Marked" if card.is_marked else "Mark" }}</span>
-                </button>
-            </form>
             {% endif %}
             <form method="post" action="/sync" class="undo-form">
                 <input type="hidden" name="next" value="/study/{{ deck }}">
@@ -265,10 +269,14 @@
             }
         }
         document.addEventListener('click', function (event) {
-            var menus = document.querySelectorAll('details.suspend-menu[open]');
+            var menus = document.querySelectorAll('details.edit-menu[open]');
             for (var i = 0; i < menus.length; i++) {
                 if (!menus[i].contains(event.target)) {
                     menus[i].removeAttribute('open');
+                    var subs = menus[i].querySelectorAll('details[open]');
+                    for (var j = 0; j < subs.length; j++) {
+                        subs[j].removeAttribute('open');
+                    }
                 }
             }
         });

--- a/src/einki/templates/study.html
+++ b/src/einki/templates/study.html
@@ -97,6 +97,34 @@
             color: #664d03;
         }
         .mark-btn.marked:hover { background: #ffe69c; }
+        .suspend-menu {
+            position: relative;
+            display: inline-block;
+        }
+        .suspend-menu > summary {
+            list-style: none;
+            cursor: pointer;
+        }
+        .suspend-menu > summary::-webkit-details-marker { display: none; }
+        .suspend-menu[open] > summary {
+            background: #e9ecef;
+        }
+        .suspend-options {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            z-index: 10;
+            margin-top: 4px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            background: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            padding: 6px;
+            min-width: 80px;
+        }
+        .suspend-options .undo-btn { width: 100%; text-align: left; }
         @media (max-width: 480px) {
             .mark-label { display: none; }
         }
@@ -127,6 +155,23 @@
         <p class="header" style="margin:0;"><a href="/decks">← Decks</a> / {{ deck }}</p>
         <div style="display:flex;gap:8px;">
             {% if card %}
+            <details class="suspend-menu">
+                <summary class="undo-btn" title="Suspend">Suspend</summary>
+                <div class="suspend-options">
+                    <form method="post" action="/suspend" class="undo-form">
+                        <input type="hidden" name="deck" value="{{ deck }}">
+                        <input type="hidden" name="card_id" value="{{ card.card_id }}">
+                        <input type="hidden" name="scope" value="card">
+                        <button type="submit" class="undo-btn">Card</button>
+                    </form>
+                    <form method="post" action="/suspend" class="undo-form">
+                        <input type="hidden" name="deck" value="{{ deck }}">
+                        <input type="hidden" name="note_id" value="{{ card.note_id }}">
+                        <input type="hidden" name="scope" value="note">
+                        <button type="submit" class="undo-btn">Note</button>
+                    </form>
+                </div>
+            </details>
             <form method="post" action="/mark_card" class="undo-form">
                 <input type="hidden" name="deck" value="{{ deck }}">
                 <input type="hidden" name="note_id" value="{{ card.note_id }}">
@@ -219,6 +264,14 @@
                 flags[i].value = '1';
             }
         }
+        document.addEventListener('click', function (event) {
+            var menus = document.querySelectorAll('details.suspend-menu[open]');
+            for (var i = 0; i < menus.length; i++) {
+                if (!menus[i].contains(event.target)) {
+                    menus[i].removeAttribute('open');
+                }
+            }
+        });
     </script>
     {% endif %}
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -106,3 +106,58 @@ def test_logout_clears_session() -> None:
     response = client.get("/")
     assert response.status_code == 302
     assert "/login" in response.headers["Location"]
+
+
+def test_suspend_requires_login() -> None:
+    """POST /suspend without a session should redirect to /login."""
+    client = _make_client()
+
+    response = client.post(
+        "/suspend",
+        data={"deck": "Default", "scope": "card", "card_id": "1"},
+    )
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_suspend_card_without_anki_redirects() -> None:
+    """POST /suspend (scope=card) with no AnkiClient redirects to /study/<deck>."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/suspend",
+        data={"deck": "Default", "scope": "card", "card_id": "1"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default"
+
+
+def test_suspend_note_without_anki_redirects() -> None:
+    """POST /suspend (scope=note) with no AnkiClient redirects to /study/<deck>."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/suspend",
+        data={"deck": "Default", "scope": "note", "note_id": "1"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default"
+
+
+def test_suspend_unknown_scope_redirects() -> None:
+    """An unknown scope must not raise — just redirect back."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/suspend",
+        data={"deck": "Default", "scope": "garbage"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default"


### PR DESCRIPTION
Introduces a 'Suspend' disclosure menu in the study header with Card / Note options. Uses AnkiConnect's suspend action; for note scope, resolves cards via findCards(query='nid:<id>'). A document-level click handler closes the menu when the user clicks outside.