### PR TITLE
Add flag picker, with NewType-typed CardId/NoteId

### DIFF
--- a/src/einki/_anki_client.py
+++ b/src/einki/_anki_client.py
@@ -38,6 +38,10 @@ class Flag(enum.IntEnum):
     PURPLE = 7
 
 
+CardId = ty.NewType("CardId", int)
+NoteId = ty.NewType("NoteId", int)
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class DeckStats:
     """Statistics for a single Anki deck."""
@@ -53,8 +57,8 @@ class DeckStats:
 class CardInfo:
     """Rendered card content from Anki's scheduler."""
 
-    card_id: int
-    note_id: int
+    card_id: CardId
+    note_id: NoteId
     question: str
     answer: str
     css: str
@@ -155,7 +159,7 @@ class AnkiClient:
             return None
         self._invoke("guiStartCardTimer")
 
-        card_id = result["cardId"]
+        card_id = CardId(result["cardId"])
         note_id = self._note_id_for_card(card_id)
         is_marked = self._is_marked(note_id)
         state, flag = self._card_state_and_flag(card_id)
@@ -182,12 +186,12 @@ class AnkiClient:
         )
         return card
 
-    def _note_id_for_card(self, card_id: int) -> int:
+    def _note_id_for_card(self, card_id: CardId) -> NoteId:
         """Map a card ID to its parent note ID."""
         note_ids: list[int] = self._invoke("cardsToNotes", cards=[card_id])
-        return note_ids[0]
+        return NoteId(note_ids[0])
 
-    def _card_state_and_flag(self, card_id: int) -> tuple[CardState, Flag]:
+    def _card_state_and_flag(self, card_id: CardId) -> tuple[CardState, Flag]:
         """Return (state, flag) for the given card.
 
         Uses AnkiConnect's ``cardsInfo``: ``type`` field
@@ -208,12 +212,12 @@ class AnkiClient:
             return CardState.LEARN, flag
         return CardState.REVIEW, flag
 
-    def _is_marked(self, note_id: int) -> bool:
+    def _is_marked(self, note_id: NoteId) -> bool:
         """Check whether a note has the 'marked' tag."""
         tags: list[str] = self._invoke("getNoteTags", note=note_id)
         return any(t.lower() == "marked" for t in tags)
 
-    def toggle_mark(self, note_id: int) -> bool:
+    def toggle_mark(self, note_id: NoteId) -> bool:
         """Toggle the 'marked' tag on a note. Returns the new marked state."""
         if self._is_marked(note_id):
             self._invoke("removeTags", notes=[note_id], tags="marked")
@@ -249,7 +253,7 @@ class AnkiClient:
         LOG.info("Undo: %s", result)
         return result
 
-    def set_flag(self, card_id: int, flag: Flag) -> None:
+    def set_flag(self, card_id: CardId, flag: Flag) -> None:
         """Set a card's colored flag (pass ``Flag.NONE`` to clear).
 
         Anki flags are categorical: a card has at most one flag at any time.
@@ -272,13 +276,13 @@ class AnkiClient:
             raise RuntimeError(msg)
         LOG.info("Set flag of card %d to %s", card_id, flag.name)
 
-    def suspend_card(self, card_id: int) -> bool:
+    def suspend_card(self, card_id: CardId) -> bool:
         """Suspend a single card until the user manually unsuspends it."""
         result: bool = self._invoke("suspend", cards=[card_id])
         LOG.info("Suspended card %d: %s", card_id, result)
         return result
 
-    def suspend_note(self, note_id: int) -> bool:
+    def suspend_note(self, note_id: NoteId) -> bool:
         """Suspend every card belonging to a note."""
         card_ids: list[int] = self._invoke("findCards", query=f"nid:{note_id}")
         if not card_ids:

--- a/src/einki/_anki_client.py
+++ b/src/einki/_anki_client.py
@@ -2,6 +2,7 @@
 
 import base64
 import dataclasses
+import enum
 import json
 import logging
 import typing as ty
@@ -11,7 +12,30 @@ LOG = logging.getLogger(__name__)
 
 _DEFAULT_URL = "http://127.0.0.1:8765"
 
-CardState = ty.Literal["new", "learn", "review"]
+
+class CardState(enum.StrEnum):
+    """Scheduling state of a card."""
+
+    NEW = "new"
+    LEARN = "learn"
+    REVIEW = "review"
+
+
+class Flag(enum.IntEnum):
+    """Anki card flag colors.
+
+    Flags are categorical: a card has at most one flag at a time.
+    Values match Anki's on-disk encoding (0 = no flag).
+    """
+
+    NONE = 0
+    RED = 1
+    ORANGE = 2
+    GREEN = 3
+    BLUE = 4
+    PINK = 5
+    TURQUOISE = 6
+    PURPLE = 7
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -38,6 +62,7 @@ class CardInfo:
     next_reviews: list[str]
     is_marked: bool
     state: CardState
+    flag: Flag
 
 
 class AnkiClient:
@@ -133,7 +158,7 @@ class AnkiClient:
         card_id = result["cardId"]
         note_id = self._note_id_for_card(card_id)
         is_marked = self._is_marked(note_id)
-        state = self._card_state(card_id)
+        state, flag = self._card_state_and_flag(card_id)
 
         card = CardInfo(
             card_id=card_id,
@@ -145,13 +170,15 @@ class AnkiClient:
             next_reviews=result.get("nextReviews", []),
             is_marked=is_marked,
             state=state,
+            flag=flag,
         )
         LOG.info(
-            "Current card: %d (note: %d, marked: %s, state: %s)",
+            "Current card: %d (note: %d, marked: %s, state: %s, flag: %s)",
             card.card_id,
             note_id,
             is_marked,
             state,
+            flag.name,
         )
         return card
 
@@ -160,20 +187,26 @@ class AnkiClient:
         note_ids: list[int] = self._invoke("cardsToNotes", cards=[card_id])
         return note_ids[0]
 
-    def _card_state(self, card_id: int) -> CardState:
-        """Return 'new', 'learn', or 'review' for the given card.
+    def _card_state_and_flag(self, card_id: int) -> tuple[CardState, Flag]:
+        """Return (state, flag) for the given card.
 
-        Uses AnkiConnect's ``cardsInfo`` ``type`` field:
-        0=new, 1=learning, 2=review, 3=relearning. Unknown values fall
-        back to ``"review"`` (matches how Anki itself buckets odd states).
+        Uses AnkiConnect's ``cardsInfo``: ``type`` field
+        (0=new, 1=learning, 2=review, 3=relearning) and ``flags``
+        (see :class:`Flag`). Unknown ``type`` values fall back to
+        ``CardState.REVIEW`` (matches how Anki itself buckets odd
+        states); unknown flag values fall back to ``Flag.NONE``.
         """
         info: list[dict[str, ty.Any]] = self._invoke("cardsInfo", cards=[card_id])
         card_type = info[0].get("type")
+        try:
+            flag = Flag(int(info[0].get("flags", 0) or 0))
+        except ValueError:
+            flag = Flag.NONE
         if card_type == 0:
-            return "new"
+            return CardState.NEW, flag
         if card_type in (1, 3):
-            return "learn"
-        return "review"
+            return CardState.LEARN, flag
+        return CardState.REVIEW, flag
 
     def _is_marked(self, note_id: int) -> bool:
         """Check whether a note has the 'marked' tag."""
@@ -215,6 +248,29 @@ class AnkiClient:
         result: bool = self._invoke("guiUndo")
         LOG.info("Undo: %s", result)
         return result
+
+    def set_flag(self, card_id: int, flag: Flag) -> None:
+        """Set a card's colored flag (pass ``Flag.NONE`` to clear).
+
+        Anki flags are categorical: a card has at most one flag at any time.
+        Setting a new flag overwrites the previous one.
+        """
+        result: list[ty.Any] = self._invoke(
+            "setSpecificValueOfCard",
+            card=card_id,
+            keys=["flags"],
+            newValues=[int(flag)],
+        )
+        # ``setSpecificValueOfCard`` reports per-key outcomes inside
+        # ``result``: each entry is either ``True`` or ``[False, message]``.
+        # AnkiConnect only sets the top-level ``error`` for protocol-level
+        # failures, so we have to inspect ``result`` explicitly.
+        for entry in result:
+            if entry is True:
+                continue
+            msg = entry[-1] if isinstance(entry, list) and entry else entry
+            raise RuntimeError(msg)
+        LOG.info("Set flag of card %d to %s", card_id, flag.name)
 
     def suspend_card(self, card_id: int) -> bool:
         """Suspend a single card until the user manually unsuspends it."""

--- a/src/einki/_app.py
+++ b/src/einki/_app.py
@@ -13,7 +13,7 @@ import flask
 import flask_login
 import werkzeug
 
-from einki._anki_client import AnkiClient, Flag
+from einki._anki_client import AnkiClient, CardId, Flag, NoteId
 from einki._sync import sync_state, trigger_sync
 
 LOG = logging.getLogger(__name__)
@@ -212,7 +212,7 @@ def _serve_media(
 def _handle_mark(anki_client: AnkiClient | None) -> werkzeug.Response:
     """Toggle the 'marked' tag on the current card's note."""
     deck = flask.request.form["deck"]
-    note_id = int(flask.request.form["note_id"])
+    note_id = NoteId(int(flask.request.form["note_id"]))
     answer_shown = flask.request.form.get("answer_shown") == "1"
     if anki_client is not None:
         anki_client.toggle_mark(note_id)
@@ -227,9 +227,9 @@ def _handle_suspend(anki_client: AnkiClient | None) -> werkzeug.Response:
     scope = flask.request.form.get("scope")
     if anki_client is not None and scope in ("card", "note"):
         if scope == "card":
-            anki_client.suspend_card(int(flask.request.form["card_id"]))
+            anki_client.suspend_card(CardId(int(flask.request.form["card_id"])))
         else:
-            anki_client.suspend_note(int(flask.request.form["note_id"]))
+            anki_client.suspend_note(NoteId(int(flask.request.form["note_id"])))
     return flask.redirect(flask.url_for("study", deck=deck))
 
 
@@ -242,7 +242,7 @@ def _handle_set_flag(anki_client: AnkiClient | None) -> werkzeug.Response:
     except (KeyError, ValueError):
         flag = None
     if anki_client is not None and flag is not None:
-        card_id = int(flask.request.form["card_id"])
+        card_id = CardId(int(flask.request.form["card_id"]))
         anki_client.set_flag(card_id, flag)
     return flask.redirect(
         flask.url_for("study", deck=deck, answer_shown="1" if answer_shown else None),
@@ -271,7 +271,7 @@ def _handle_answer(anki_client: AnkiClient | None) -> str | werkzeug.Response:
     """Process a card answer, guarding against stale cards."""
     ease = int(flask.request.form["ease"])
     deck = flask.request.form["deck"]
-    expected_card_id = int(flask.request.form["card_id"])
+    expected_card_id = CardId(int(flask.request.form["card_id"]))
     if anki_client is not None:
         current = anki_client.current_card()
         if current is not None and current.card_id == expected_card_id:

--- a/src/einki/_app.py
+++ b/src/einki/_app.py
@@ -13,7 +13,7 @@ import flask
 import flask_login
 import werkzeug
 
-from einki._anki_client import AnkiClient
+from einki._anki_client import AnkiClient, Flag
 from einki._sync import sync_state, trigger_sync
 
 LOG = logging.getLogger(__name__)
@@ -173,6 +173,12 @@ def _register_anki_routes(  # noqa: C901
         """Suspend the current card or note, then advance to the next card."""
         return _handle_suspend(anki_client)
 
+    @app.route("/set_flag", methods=["POST"])
+    @flask_login.login_required  # type: ignore[untyped-decorator]
+    def set_flag() -> werkzeug.Response:
+        """Set (or clear) the colored flag on the current card."""
+        return _handle_set_flag(anki_client)
+
     @app.route("/media/<path:filename>")
     @flask_login.login_required  # type: ignore[untyped-decorator]
     def media(filename: str) -> werkzeug.Response:
@@ -225,6 +231,22 @@ def _handle_suspend(anki_client: AnkiClient | None) -> werkzeug.Response:
         else:
             anki_client.suspend_note(int(flask.request.form["note_id"]))
     return flask.redirect(flask.url_for("study", deck=deck))
+
+
+def _handle_set_flag(anki_client: AnkiClient | None) -> werkzeug.Response:
+    """Set the flag on the current card, preserving answer-shown state."""
+    deck = flask.request.form["deck"]
+    answer_shown = flask.request.form.get("answer_shown") == "1"
+    try:
+        flag = Flag(int(flask.request.form["flag"]))
+    except (KeyError, ValueError):
+        flag = None
+    if anki_client is not None and flag is not None:
+        card_id = int(flask.request.form["card_id"])
+        anki_client.set_flag(card_id, flag)
+    return flask.redirect(
+        flask.url_for("study", deck=deck, answer_shown="1" if answer_shown else None),
+    )
 
 
 def _handle_undo(anki_client: AnkiClient | None) -> str | werkzeug.Response:

--- a/src/einki/templates/study.html
+++ b/src/einki/templates/study.html
@@ -134,6 +134,24 @@
             padding-left: 12px;
             border-left: 2px solid #dee2e6;
         }
+        .flag-sub > summary {
+            list-style: none;
+            cursor: pointer;
+        }
+        .flag-sub > summary::-webkit-details-marker { display: none; }
+        .flag-sub[open] > summary {
+            background: #e9ecef;
+        }
+        .flag-sub-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            margin-top: 4px;
+            padding-left: 12px;
+            border-left: 2px solid #dee2e6;
+        }
+        .flag-sub-panel .undo-form { margin: 0; }
+        .flag-sub-panel .undo-btn.current { background: #e9ecef; font-weight: 600; }
         .stats {
             display: flex;
             justify-content: flex-start;
@@ -187,6 +205,32 @@
                                 <input type="hidden" name="scope" value="note">
                                 <button type="submit" class="undo-btn">Note</button>
                             </form>
+                        </div>
+                    </details>
+                    <details class="flag-sub">
+                        <summary class="undo-btn" title="Flag">Flag ▸</summary>
+                        <div class="flag-sub-panel">
+                            {% for flag_value, flag_name in [
+                                (1, 'Red'),
+                                (2, 'Orange'),
+                                (3, 'Green'),
+                                (4, 'Blue'),
+                                (5, 'Pink'),
+                                (6, 'Turquoise'),
+                                (7, 'Purple'),
+                            ] %}
+                            <form method="post" action="/set_flag" class="undo-form">
+                                <input type="hidden" name="deck" value="{{ deck }}">
+                                <input type="hidden" name="card_id" value="{{ card.card_id }}">
+                                <input type="hidden" name="answer_shown" value="{{ '1' if answer_shown else '0' }}" class="answer-shown-flag">
+                                <input type="hidden" name="flag" value="{{ 0 if card.flag == flag_value else flag_value }}">
+                                <button
+                                    type="submit"
+                                    class="undo-btn{{ ' current' if card.flag == flag_value else '' }}"
+                                    title="{{ 'Clear flag' if card.flag == flag_value else 'Set ' + flag_name + ' flag' }}"
+                                >{{ flag_name }}</button>
+                            </form>
+                            {% endfor %}
                         </div>
                     </details>
                 </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -238,3 +238,63 @@ def test_suspend_unknown_scope_redirects() -> None:
 
     assert response.status_code == 302
     assert response.headers["Location"] == "/study/Default"
+
+
+def test_set_flag_requires_login() -> None:
+    """POST /set_flag without a session should redirect to /login."""
+    client = _make_client()
+
+    response = client.post(
+        "/set_flag",
+        data={"deck": "Default", "card_id": "1", "flag": "1"},
+    )
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_set_flag_without_anki_redirects() -> None:
+    """POST /set_flag with no AnkiClient redirects to /study/<deck>."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/set_flag",
+        data={"deck": "Default", "card_id": "1", "flag": "3"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default"
+
+
+def test_set_flag_preserves_answer_shown() -> None:
+    """answer_shown=1 should round-trip through the redirect."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/set_flag",
+        data={
+            "deck": "Default",
+            "card_id": "1",
+            "flag": "0",
+            "answer_shown": "1",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default?answer_shown=1"
+
+
+def test_set_flag_invalid_value_redirects() -> None:
+    """Out-of-range flag values must not raise — just redirect back."""
+    client = _make_client()
+    _login(client)
+
+    response = client.post(
+        "/set_flag",
+        data={"deck": "Default", "card_id": "1", "flag": "99"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/study/Default"


### PR DESCRIPTION
Adds a flag picker to the study page's Edit menu, plus a small typing improvement to prevent ID-mixup bugs.

## 1. Flag picker

A "Flag ▸" submenu under Edit, mirroring the Suspend submenu's layout: a vertical list of text-labeled buttons (Red, Orange, Green, Blue, Pink, Turquoise, Purple). The card's current flag, if any, is highlighted; clicking it again clears the flag, clicking another replaces it. This matches Anki's native semantics — flags are categorical (one per card), not tag-like.

- **`AnkiClient`**: new `Flag` `IntEnum`; `CardState` promoted to `StrEnum` for consistency; `CardInfo.flag`; `set_flag(card_id, flag)` using `setSpecificValueOfCard`.
- **Per-key result inspection in `set_flag`**: `setSpecificValueOfCard` reports per-field outcomes inside `result` (each entry is `True` or `[False, msg]`), separately from the top-level `error` channel that `_invoke` already raises on. Without inspecting `result`, a malformed write (e.g. wrong value type) silently no-ops. `set_flag` now raises `RuntimeError` if any per-key entry indicates failure.
- **`POST /set_flag`**: preserves `answer_shown` like `/mark_card`. Invalid flag values are silently dropped, matching `/suspend`'s behaviour for unknown scopes.
- **`study.html`**: Flag submenu wired to `/set_flag`, current option highlighted via background + bold.
- **Tests**: 4 new tests covering auth, no-AnkiClient fallback, `answer_shown` round-trip, and invalid flag values.

## 2. `CardId` / `NoteId` via `typing.NewType`

Card IDs and note IDs are both opaque integers in AnkiConnect's API, so nothing in the type system stopped us from swapping them. Defined `CardId = NewType("CardId", int)` and `NoteId = NewType("NoteId", int)`: zero runtime cost, but mypy now treats them as distinct nominal types. Wrapping happens at the two boundaries that produce raw ints — AnkiConnect responses (`current_card`, `_note_id_for_card`) and Flask form parsing — so internal swaps are now a static error. Verified by injecting three swap variants in a temporary file; mypy flagged each one.

## Verification
- `bash scripts/run_checks.sh` locally: ruff-lint, ruff-format, ty, mypy, pytest — all pass (29/29 tests, 45% coverage).
- Manually exercised against a running Anki instance: setting, replacing, and clearing flags persist; the highlighted option in the menu reflects `cardsInfo.flags`; flags are visible in Anki desktop.