### PR TITLE
Sync run_checks.sh with CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# IMPORTANT: keep this in sync with scripts/run_checks.sh.
+# If you change a command here, mirror it in the script (and vice versa).
 name: CI
 
 on:

--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -1,23 +1,38 @@
 #!/usr/bin/env bash
-# Run all checks: lint, format, type-check, and test.
+# Run all CI checks locally.
 # Run this file from repo root.
+#
+# IMPORTANT: keep this in sync with .github/workflows/ci.yml.
+# If you change a command here, mirror it in the workflow (and vice versa).
+#
+# Like the CI matrix (fail-fast: false), this script runs every check even if
+# an earlier one fails, then exits nonzero if any failed.
 
-set -e
+set -u
 set -o pipefail
 
-echo "=== ruff check ==="
-uv run ruff check src/ tests/ scripts/
+failed=()
 
-echo "=== ruff format ==="
-uv run ruff format --check src/ tests/ scripts/
+run_check() {
+    local name=$1
+    shift
+    echo "=== ${name} ==="
+    if ! "$@"; then
+        failed+=("${name}")
+    fi
+}
 
-echo "=== ty ==="
-uv run ty check src/ tests/
+run_check "ruff-lint"   uv run ruff check .
+run_check "ruff-format" uv run ruff format --check .
+run_check "ty"          uv run ty check
+run_check "mypy"        uv run mypy src tests
+run_check "pytest"      uv run pytest --cov --cov-report=term-missing
 
-echo "=== mypy ==="
-uv run mypy src/ tests/
-
-echo "=== pytest ==="
-uv run pytest
-
-echo "=== All checks passed ==="
+echo
+if [ ${#failed[@]} -eq 0 ]; then
+    echo "=== All checks passed ==="
+    exit 0
+else
+    echo "=== Failed: ${failed[*]} ==="
+    exit 1
+fi


### PR DESCRIPTION
Aligns `scripts/run_checks.sh` with the matrix in `.github/workflows/ci.yml` so local runs mirror CI exactly.

- Same five commands, same args, same order: `ruff check .`, `ruff format --check .`, `ty check`, `mypy src tests`, `pytest --cov --cov-report=term-missing`.
- Continues past failures (like `fail-fast: false` in the matrix) and exits nonzero with a summary if any failed.
- Both files carry a note pointing at the other so future changes stay in sync.

Based on #9 — retarget to `main` once that merges, or merge in order.