### PR TITLE
docs: note that bury is not supported (AnkiConnect limitation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The browser UI keeps things lean but covers the day-to-day Anki workflow:
 - **Sync** with AnkiWeb on demand from the header.
 - **Image** fields render inline.
 
+Burying a card or note (the usual companion to *Suspend*) is **not
+supported**: AnkiConnect does not expose a bury endpoint, so einki
+cannot offer the action without forking the plugin. Bury from a
+desktop or mobile Anki client instead.
+
 ## Kindle compatibility
 
 Designed for and tested on the Kindle's built-in "Experimental"


### PR DESCRIPTION
While testing the original bury implementation, the action failed at runtime with `RuntimeError: unsupported action`. Investigation:

- Tried `bury`, `buryCards`, `buryNotes` against the running AnkiConnect (25.2.25.0) — all return `unsupported action`.
- Inspected upstream plugin source (25.2.25.0 and the latest 25.11.9.0): **no bury endpoint exists**. AnkiConnect only exposes `suspend` / `unsuspend`.
- The only way to manually bury via AnkiConnect is `setSpecificValueOfCard` with `warning_check=true`, mutating internal scheduler fields — too brittle to ship.

So the feature implementation is reverted and the README now states clearly that bury isn't available, pointing users at desktop/mobile Anki for that action.

Closes #14.