### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 
 <p align="center"><em>Anki for e-ink devices.</em></p>
 
-einki lets you review your Anki flashcards from anywhere on your Kindle's
-built-in web browser. It is a small Flask server that drives a headless
-copy of Anki in the background — scheduling, grading, and sync are all
-done by real Anki, so your deck stays compatible with every other Anki
-client.
+einki lets you review your Anki flashcards from anywhere on your
+Kindle's built-in web browser. Real Anki runs in the background, so
+your deck stays fully compatible with every other Anki client —
+scheduling, grading, and sync are unchanged.
 
 einki is a **review-only** client: it does not support creating new
 cards or editing existing ones. Author your decks in the desktop or
 mobile Anki app, sync them to AnkiWeb, and use einki on the Kindle
 purely to work through the daily queue.
+
+einki also **requires an internet connection**. The Kindle talks to
+the einki server over HTTPS on every action, so reviews do not work
+offline.
 
 ## Screenshots
 
@@ -78,11 +81,12 @@ flowchart LR
     anki <-. "sync (optional)" .-> ankiweb
 ```
 
-einki ships as a single opinionated stack: nginx terminates TLS, a
-Let's Encrypt cert is obtained and renewed against a DuckDNS
-subdomain, and einki talks to a headless Anki via AnkiConnect. The
-only genuinely optional piece is the AnkiWeb link — everything else
-is baked into the compose file and nginx config.
+einki ships as a single opinionated stack: a small Flask server
+(einki) drives a headless copy of Anki via AnkiConnect, nginx
+terminates TLS, and a Let's Encrypt cert is obtained and renewed
+against a DuckDNS subdomain. The only genuinely optional piece is
+the AnkiWeb link — everything else is baked into the compose file
+and nginx config.
 
 Running with a different TLS setup (a paid domain, your own nginx
 in front, no TLS at all on a trusted LAN, etc.) is supported, but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "einki"
-version = "0.1.0"
+version = "0.2.0"
 description = "Anki flashcard server for Kindle e-ink browsers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "einki"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Bundles two commits already on local `main` for review before pushing to `origin/main`:

- **`5b0f71d` docs: lead README with non-technical intro, note no offline support** — moves the Flask/AnkiConnect mechanics out of the opening paragraph into the Architecture section, and notes the internet-connection requirement upfront alongside the existing review-only caveat.
- **`0357d33` Bump version to 0.2.0** — `pyproject.toml` + `uv.lock`. Accumulated user-facing features since 0.1.0: suspend card/note (#3), inline image rendering via /media (#4), flag picker with on-card indicator (#7, #12), marked-star indicator (#12). Internal: CI workflow (#6, #9), `run_checks.sh` sync (#11), expanded tests, and NewType-typed `CardId`/`NoteId`.

No code changes — docs + version metadata only.