### PR TITLE
Add swap file provisioning script for Lightsail deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,23 @@ cd ~/einki
 
 Log out and back in so the `docker` group takes effect.
 
-### 4. Configure secrets
+### 4. Add swap (recommended on the 1 GB tier)
+
+The 1 GB Lightsail tier ships with no swap. Without it, transient
+memory pressure (apt unattended-upgrades, snapd refresh, log rotation)
+can deadlock the kernel and trigger AWS status check failures — visible
+on the Lightsail metrics page even when CPU usage stays low. A small
+swap file turns these hangs into graceful slowdowns.
+
+```bash
+./scripts/add_swap.sh                  # 2 GB swap file, vm.swappiness=10
+```
+
+The script is idempotent (safe to re-run) and persists the swap file
+in `/etc/fstab` so it survives reboots. Skip this step on tiers with
+≥ 4 GB RAM.
+
+### 5. Configure secrets
 
 On the server:
 
@@ -160,7 +176,7 @@ $EDITOR .env                           # follow the comments in the file
 
 `.env` is gitignored and never leaves the server.
 
-### 5. Bootstrap HTTPS and start the stack
+### 6. Bootstrap HTTPS and start the stack
 
 ```bash
 ./scripts/setup_https.sh
@@ -184,7 +200,7 @@ current IP. No cron, no systemd.
 See [`docker/nginx/README.md`](docker/nginx/README.md) for the TLS
 pipeline in more detail.
 
-### 6. First-time AnkiWeb sync (optional)
+### 7. First-time AnkiWeb sync (optional)
 
 If you want your existing AnkiWeb collection on the server, sync once
 via VNC. AnkiConnect can't click through the "Download from AnkiWeb?"

--- a/scripts/add_swap.sh
+++ b/scripts/add_swap.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# add_swap.sh — provision a swap file on a Lightsail (or any Ubuntu) host.
+#
+# The 1 GB Lightsail tier ships with no swap. Under memory pressure (apt
+# unattended-upgrades, snapd refresh, log rotation, …) the kernel can stall
+# before the OOM killer reclaims memory, which manifests as AWS status check
+# failures with low CPU. A small swap file turns these hangs into graceful
+# slowdowns.
+#
+# The script is idempotent: re-running it is a no-op once swap is active.
+#
+# Usage:
+#   ./scripts/add_swap.sh           # default 2 GB
+#   SWAP_SIZE_GB=4 ./scripts/add_swap.sh
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SWAP_FILE="${SWAP_FILE:-/swapfile}"
+SWAP_SIZE_GB="${SWAP_SIZE_GB:-2}"
+SWAPPINESS="${SWAPPINESS:-10}"
+
+if [ -n "$(sudo swapon --show --noheadings)" ]; then
+    echo "Swap is already active:"
+    sudo swapon --show
+    exit 0
+fi
+
+if [ -e "$SWAP_FILE" ]; then
+    echo "Error: $SWAP_FILE already exists but is not active. Inspect and remove it before re-running." >&2
+    exit 1
+fi
+
+echo "Allocating ${SWAP_SIZE_GB} GB at ${SWAP_FILE}..."
+if ! sudo fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE" 2>/dev/null; then
+    echo "fallocate unsupported on this filesystem, falling back to dd..."
+    sudo dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=progress
+fi
+
+sudo chmod 600 "$SWAP_FILE"
+sudo mkswap "$SWAP_FILE"
+sudo swapon "$SWAP_FILE"
+
+if ! grep -qE "^${SWAP_FILE}[[:space:]]" /etc/fstab; then
+    echo "${SWAP_FILE} none swap sw 0 0" | sudo tee -a /etc/fstab >/dev/null
+    echo "Added ${SWAP_FILE} to /etc/fstab."
+fi
+
+SYSCTL_CONF=/etc/sysctl.d/99-einki-swappiness.conf
+if [ ! -f "$SYSCTL_CONF" ]; then
+    echo "vm.swappiness=${SWAPPINESS}" | sudo tee "$SYSCTL_CONF" >/dev/null
+    sudo sysctl --system >/dev/null
+    echo "Set vm.swappiness=${SWAPPINESS} (persisted in ${SYSCTL_CONF})."
+fi
+
+echo ""
+echo "Done. Current memory + swap:"
+free -h


### PR DESCRIPTION
## Why

The 1 GB Lightsail tier ships with **no swap**. Under transient memory pressure (apt unattended-upgrades, snapd refresh, log rotation), the kernel can stall before the OOM killer reclaims memory — observed in production on \`lightsail2\` as AWS status check failures starting May 18 ~05:00 UTC with low reported CPU. \`journalctl\` from that boot shows the snapd watchdog timing out at the same minute:

\`\`\`
May 18 05:00:01 systemd[1]: snapd.service: Watchdog timeout (limit 5min)!
\`\`\`

A small swap file converts these hangs into graceful slowdowns.

## What

- **\`scripts/add_swap.sh\`** — idempotent provisioning script:
  - 2 GB file at \`/swapfile\` via \`fallocate\` (falls back to \`dd\`).
  - \`chmod 600\`, \`mkswap\`, \`swapon\`.
  - Persists in \`/etc/fstab\` and sets \`vm.swappiness=10\` via \`/etc/sysctl.d/99-einki-swappiness.conf\`.
  - No-op if swap is already active. Refuses to overwrite an existing \`/swapfile\`.
  - Configurable via \`SWAP_SIZE_GB\`, \`SWAP_FILE\`, \`SWAPPINESS\` env vars.
- **\`README.md\`** — new step 4 in the Lightsail deploy section explaining the symptom (status checks failing with low CPU) and pointing at the script. Steps 4–6 renumbered to 5–7.

## Testing

- \`bash -n scripts/add_swap.sh\` passes.
- Not yet executed on the affected instance — will run after merge.