### PR TITLE
Apply note type CSS via .card wrapper and document VNC sync dance

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,25 @@ If the sync token doesn't persist after a restart (rare), run
 `scripts/debug_anki.sh` and check that `syncKey` in `prefs21.db` is
 non-empty.
 
+**When you'll need the VNC dance again.** This is not strictly a
+one-off. Any *full sync* needs the GUI, because AnkiConnect cannot
+click through Anki's one-way "Download from AnkiWeb? / Upload to
+AnkiWeb?" dialog. Two cases trigger it:
+
+- **Pulling AnkiWeb over the host.** Whenever you want to overwrite
+  the server's local collection with the AnkiWeb copy (a full
+  *download*), reconnect over VNC and confirm the direction by hand.
+- **Schema changes.** Anki forces a full sync whenever the collection
+  *schema* changes — most commonly when you add or edit a **note
+  type**, add or remove a field, or change a card template. The next
+  sync then blocks on the upload/download dialog, so AnkiConnect's
+  automatic sync stalls until you clear it once over VNC.
+
+In both cases the steps are the same as above: open the tunnel
+(`ssh -L 5900:localhost:5900 <host>`), point a VNC viewer at
+`localhost:5900`, click *Sync* in the Anki GUI, and confirm the
+correct direction. Automatic AnkiConnect syncs resume afterwards.
+
 ## Running a different setup
 
 The shipped configuration is HTTPS via DuckDNS + Let's Encrypt. There

--- a/src/einki/_anki_client.py
+++ b/src/einki/_anki_client.py
@@ -67,6 +67,16 @@ class CardInfo:
     is_marked: bool
     state: CardState
     flag: Flag
+    ordinal: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _CardDetails:
+    """Per-card scheduling details parsed from a ``cardsInfo`` response."""
+
+    state: CardState
+    flag: Flag
+    ordinal: int
 
 
 class AnkiClient:
@@ -162,7 +172,7 @@ class AnkiClient:
         card_id = CardId(result["cardId"])
         note_id = self._note_id_for_card(card_id)
         is_marked = self._is_marked(note_id)
-        state, flag = self._card_state_and_flag(card_id)
+        details = self._card_details(card_id)
 
         card = CardInfo(
             card_id=card_id,
@@ -173,16 +183,17 @@ class AnkiClient:
             buttons=result.get("buttons", [1, 2, 3]),
             next_reviews=result.get("nextReviews", []),
             is_marked=is_marked,
-            state=state,
-            flag=flag,
+            state=details.state,
+            flag=details.flag,
+            ordinal=details.ordinal,
         )
         LOG.info(
             "Current card: %d (note: %d, marked: %s, state: %s, flag: %s)",
             card.card_id,
             note_id,
             is_marked,
-            state,
-            flag.name,
+            card.state,
+            card.flag.name,
         )
         return card
 
@@ -191,12 +202,13 @@ class AnkiClient:
         note_ids: list[int] = self._invoke("cardsToNotes", cards=[card_id])
         return NoteId(note_ids[0])
 
-    def _card_state_and_flag(self, card_id: CardId) -> tuple[CardState, Flag]:
-        """Return (state, flag) for the given card.
+    def _card_details(self, card_id: CardId) -> _CardDetails:
+        """Return scheduling state, flag, and template ordinal for a card.
 
         Uses AnkiConnect's ``cardsInfo``: ``type`` field
-        (0=new, 1=learning, 2=review, 3=relearning) and ``flags``
-        (see :class:`Flag`). Unknown ``type`` values fall back to
+        (0=new, 1=learning, 2=review, 3=relearning), ``flags``
+        (see :class:`Flag`), and ``ord`` (0-based template index within
+        the note type). Unknown ``type`` values fall back to
         ``CardState.REVIEW`` (matches how Anki itself buckets odd
         states); unknown flag values fall back to ``Flag.NONE``.
         """
@@ -206,11 +218,14 @@ class AnkiClient:
             flag = Flag(int(info[0].get("flags", 0) or 0))
         except ValueError:
             flag = Flag.NONE
+        ordinal = int(info[0].get("ord", 0) or 0)
         if card_type == 0:
-            return CardState.NEW, flag
-        if card_type in (1, 3):
-            return CardState.LEARN, flag
-        return CardState.REVIEW, flag
+            state = CardState.NEW
+        elif card_type in (1, 3):
+            state = CardState.LEARN
+        else:
+            state = CardState.REVIEW
+        return _CardDetails(state=state, flag=flag, ordinal=ordinal)
 
     def _is_marked(self, note_id: NoteId) -> bool:
         """Check whether a note has the 'marked' tag."""

--- a/src/einki/templates/study.html
+++ b/src/einki/templates/study.html
@@ -308,7 +308,7 @@
             <span class="marked-indicator">{% if card.is_marked %}★{% endif %}</span>
             <span class="flag-indicator flag-{{ card.flag.name | lower }}">{% if card.flag %}{{ card.flag.name | capitalize }} ■{% endif %}</span>
         </div>
-        {{ card.question | safe }}
+        <div class="card card{{ card.ordinal + 1 }}">{{ card.question | safe }}</div>
     </div>
 
     <button class="show-answer-btn" id="show-btn"{% if answer_shown %} style="display:none"{% endif %} onclick="showAnswer()">Show Answer</button>
@@ -319,7 +319,7 @@
                 <span class="marked-indicator">{% if card.is_marked %}★{% endif %}</span>
                 <span class="flag-indicator flag-{{ card.flag.name | lower }}">{% if card.flag %}{{ card.flag.name | capitalize }} ■{% endif %}</span>
             </div>
-            {{ card.answer | safe }}
+            <div class="card card{{ card.ordinal + 1 }}">{{ card.answer | safe }}</div>
         </div>
         <form method="post" action="/answer_card">
             <input type="hidden" name="deck" value="{{ deck }}">


### PR DESCRIPTION
Lands the two commits from the local `ops/add-swap-file` branch that were created after PR #18 merged. Cherry-picked cleanly onto current `main`; all CI checks pass locally (ruff, ty, mypy, pytest).

## Changes

- **Apply note type CSS via `.card` wrapper** — Anki note CSS is keyed on a `.card` wrapper (and `.cardN` per template ordinal) that einki never rendered, so the base `.card` rule was inert while per-field rules already worked. Wrap question/answer field HTML in `<div class="card cardN">` so base font, color, background, and centering cascade as in real Anki. The template ordinal is plumbed through `CardInfo` via a new `_CardDetails` struct parsed from the existing `cardsInfo` response (no extra AnkiConnect round-trip).
- **Document the VNC sync dance** — README note on when a full AnkiWeb sync requires the VNC step.

Recommend **squash and merge**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>