### PR TITLE
Enable gzip and TLS session resumption in nginx

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,4 +1,45 @@
 # --------------------------------------------------------------------------
+# Performance logging (disabled by default)
+# --------------------------------------------------------------------------
+# Uncomment this block *and* the matching `access_log` line in the HTTPS
+# server below to diagnose slow page loads (e.g. the Kindle browser feeling
+# sluggish compared with a desktop browser). Then reload nginx:
+#
+#   docker compose exec nginx nginx -t && docker compose exec nginx nginx -s reload
+#   docker compose logs -f nginx
+#
+# Fields worth reading:
+#   req       total time nginx spent on the request, client-visible
+#   upstream  time the einki Flask app took to respond
+#   reused    "r" if the TLS session was resumed, "." if a full handshake
+#   conn      connection serial number
+#   reqs      requests served so far on that connection
+#
+# Interpreting the numbers: `upstream` is server-side work and should be
+# roughly the same for every device. If `req` is much larger than `upstream`
+# only on the Kindle, the bottleneck is the network or TLS, not the app.
+#
+# Beware that `req` stops when nginx hands the last byte to the kernel socket
+# buffer, not when the client acknowledges it. A ~20 KB page fits in that
+# buffer, so `req == upstream` does *not* prove the client downloaded it
+# quickly — it only proves nginx never had to wait.
+#
+# `conn` and `reqs` reveal whether the client reuses connections: a changing
+# `conn` with `reqs=1` on every line means a new TCP connection (and a new TLS
+# handshake) per action, which is expensive on the Kindle's slow CPU. A steady
+# `conn` with a climbing `reqs` means keepalive is working.
+#
+# This log_format must stay in the `http` context, which is where nginx
+# includes `conf.d/*.conf` from — it cannot be moved inside a `server` block.
+#
+# log_format perf '$remote_addr "$request" $status '
+#                 'req=$request_time upstream=$upstream_response_time '
+#                 'bytes=$body_bytes_sent '
+#                 'tls=$ssl_protocol reused=$ssl_session_reused '
+#                 'conn=$connection reqs=$connection_requests '
+#                 'ua="$http_user_agent"';
+
+# --------------------------------------------------------------------------
 # HTTP server — redirect all traffic to HTTPS
 # --------------------------------------------------------------------------
 server {
@@ -33,10 +74,41 @@ server {
     # Modern cipher suite — balances security and compatibility
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
 
+    # --- TLS session resumption ---
+    # nginx defaults to `ssl_session_cache none`, so every connection pays for
+    # a full handshake. That is a few milliseconds on a desktop but a real
+    # cost on the Kindle's low-power ARM CPU, which reconnects for every tap.
+    # A shared cache also lets any worker process resume a session started on
+    # another worker. 10m holds roughly 40k sessions.
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
     # --- HSTS (HTTP Strict Transport Security) ---
     # Tell browsers to always use HTTPS for this domain for 1 year.
     # After the first visit, the browser will never send an HTTP request.
     add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # --- Performance logging ---
+    # Uncomment together with the `log_format perf` block at the top of this
+    # file. The default path is symlinked to stdout in the nginx image, so the
+    # lines show up in `docker compose logs nginx`.
+    #
+    # access_log /var/log/nginx/access.log perf;
+
+    # --- Compression ---
+    # Study pages are ~20 KB of uncompressed HTML (much of it the inline
+    # stylesheet), which needs several round trips to reach the Kindle.
+    # Compressed they land near 4 KB, small enough for TCP's initial
+    # congestion window, so the page arrives in a single round trip.
+    #
+    # `gzip on` always covers text/html, so gzip_types only needs to name the
+    # extra types. gzip_min_length skips the 247-byte redirects, which would
+    # only grow. gzip_vary adds `Vary: Accept-Encoding` so caches keep the
+    # compressed and uncompressed variants apart.
+    gzip on;
+    gzip_types text/css text/plain application/javascript application/json;
+    gzip_min_length 1024;
+    gzip_vary on;
 
     # --- Reverse proxy to einki ---
     location / {


### PR DESCRIPTION
## Why

Reviewing on the Kindle felt sluggish while the same pages were near-instant on a desktop. Adding a temporary nginx log format that separates `$request_time` from `$upstream_response_time` showed that **server time was identical on both devices** (~0.39 s per card), ruling out einki and AnkiConnect as the cause of the difference. The cost was downstream of nginx: transfer, TLS, and rendering.

## Changes

**gzip** — study pages were served uncompressed at ~20 KB, needing several round trips to reach the Kindle. Measured on the deployed server, pages dropped to **~3.5 KB** on the wire (~5.7x), which fits inside TCP's initial congestion window so the page arrives in a single round trip.

`gzip on` already covers `text/html`, so `gzip_types` only names the extra types. `gzip_min_length` skips the 247-byte redirects, which would only grow under compression. Verified that no `gzip_proxied` setting is needed: it keys off a `Via` header in the *request*, which browsers do not send, so proxied HTML is compressed normally.

**TLS session resumption** — nginx defaults to `ssl_session_cache none`, so every connection paid for a full handshake. A shared cache also lets any worker resume a session started on another worker. Verified against the default with `openssl s_client`:

| | 2nd connection | log |
|---|---|---|
| `shared:SSL:10m` | `Reused, TLSv1.2` | `reused=r` |
| `none` (default) | `New, TLSv1.2` | `reused=.` |

Note this test forced TLS 1.2 to isolate the cache. Real clients here negotiate TLS 1.3, where resumption is ticket-based, and they still report `reused=.` — so this is a correctness improvement rather than a measured win for those clients.

**`perf` log format (commented out)** — kept for on-demand diagnosis. It records request and upstream time separately, plus `$connection`/`$connection_requests` to show whether a client reuses connections. Left disabled by default because a public host attracts constant scanner traffic that floods the log.

## Notes for future work

The logging revealed that the Kindle opens a **new TCP connection for every card** and never resumes TLS, so it pays a full handshake each time. That is client-side power management and is not fixable from the server.

One caveat worth recording: `$request_time` stops when nginx hands the last byte to the kernel socket buffer, not when the client acknowledges it. A ~20 KB page fits in that buffer, so `req == upstream` does **not** prove the client downloaded it quickly. This is documented in the config comments to avoid a misreading later.

Still on the table, all app-side: `_handle_answer` makes 5 AnkiConnect calls to read a single card ID (~100 ms per answer), the `POST -> 302 -> GET` round trip could be collapsed, and the 6 KB inline stylesheet could move to a cached static file.

## Testing

Every directive was validated in a throwaway `nginx:alpine` container against a stub upstream: `nginx -t` passes, gzip confirmed via `Content-Encoding: gzip` and `Vary: Accept-Encoding` on proxied HTML, and the log format verified to emit exactly one line per request. Post-deploy numbers in the description are from the live server.